### PR TITLE
Improve file reveal for saved inbox items

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -106,20 +106,11 @@ function savePendingFile(event, _id) {
 
 function revealPendingFile(event, _id) {
   const file = inboxItems.get(_id);
+
   if (!file) return;
-
   if (!file.savedPath || file.savedPath === "") return;
-
-  const filePath = file.savedPath;
-
-  exec(`explorer.exe "${path.dirname(filePath)}"`, (error, stdout, stderr) => {
-    if (error) {
-      console.error(`exec error: ${error}`);
-      return;
-    }
-    console.log(`stdout: ${stdout}`);
-    console.error(`stderr: ${stderr}`);
-  });
+  
+  shell.showItemInFolder(file.savedPath);
 }
 
 async function handleFileOpen(e, path) {


### PR DESCRIPTION
This PR removes the janky exec(explorer.exe) call and replaces it with the electron-provided shell.showItemInFolder().