### PR TITLE
Show raw URL in UI + server regex bugfix

### DIFF
--- a/src/components/QrComponent.jsx
+++ b/src/components/QrComponent.jsx
@@ -1,9 +1,12 @@
 import React, {useState, useEffect} from 'react';
 import QRCode from 'qrcode';
 
-const QrComponent = ({url}) => {
+import ResponsiveButton from './ResponsiveButton';
+
+const QrComponent = ({url, alignment}) => {
   const [src, setSrc] = useState("");
   const [qrHoverMsg, setQrHoverMsg] = useState("Click to copy URL to clipboard");
+  const [showUrl, setShowUrl] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -26,9 +29,14 @@ const QrComponent = ({url}) => {
   }
 
   return (
-    <div className="qr-wrapper" onClick={handleQRClick} onMouseLeave={() => setQrHoverMsg("Click to copy URL to clipboard")}>
-      {src ? <img src={src} /> : <p>Loading QR...</p>}
-      <div className="qr-overlay"><div className="qr-overlay-text">{qrHoverMsg}</div></div>
+    <div style={{display: "flex", flexDirection: "column", alignItems: "center", gap: "10px", fontSize: "0.8rem"}}>
+      <div className="qr-code" style={{position: "relative", width: "fit-content", height: "fit-content", aspectRatio: "1/1", textAlign: "center", fontStyle: "italic", cursor: "pointer", borderRadius: "8px", whiteSpace: "normal"}} onClick={handleQRClick} onMouseLeave={() => setQrHoverMsg("Click to copy URL to clipboard")}>
+        {src ? <img src={src} /> : <p>Loading QR...</p>}
+        <div className="qr-overlay"><div className="qr-overlay-text">{qrHoverMsg}</div></div>
+      </div>
+
+      {showUrl ? (<div style={{alignSelf: {alignment}}}>{url.toLowerCase()}</div>) : null}
+      <ResponsiveButton selected={false} enabled={true} buttonAction={()=>{setShowUrl(!showUrl)}} label={showUrl ? "Hide" : "Show"} customStyle={{borderRadius: "5px", width: "fit-content", paddingLeft: "10px", paddingRight: "10px", height: "30px"}} shadeA="#282828" shadeB="#303030" shadeC="#383838" />
     </div>
   );
 }

--- a/src/components/QrComponent.jsx
+++ b/src/components/QrComponent.jsx
@@ -29,14 +29,17 @@ const QrComponent = ({url, alignment, shadeA="#282828", shadeB="#303030", shadeC
   }
 
   return (
-    <div style={{display: "flex", flexDirection: "column", alignItems: "center", gap: "10px", fontSize: "0.8rem"}}>
+    <div style={{display: "flex", flexDirection: "column", alignItems: alignment , gap: "10px", fontSize: "0.8rem"}}>
       <div className="qr-code" style={{position: "relative", width: "fit-content", height: "fit-content", aspectRatio: "1/1", textAlign: "center", fontStyle: "italic", cursor: "pointer", borderRadius: "8px", whiteSpace: "normal"}} onClick={handleQRClick} onMouseLeave={() => setQrHoverMsg("Click to copy URL to clipboard")}>
         {src ? <img src={src} /> : <p>Loading QR...</p>}
         <div className="qr-overlay"><div className="qr-overlay-text">{qrHoverMsg}</div></div>
       </div>
 
-      {showUrl ? (<div style={{alignSelf: {alignment}}}>{url.toLowerCase()}</div>) : null}
-      <ResponsiveButton selected={false} enabled={true} buttonAction={()=>{setShowUrl(!showUrl)}} label={showUrl ? "Hide" : "Show"} customStyle={{borderRadius: "5px", width: "fit-content", paddingLeft: "10px", paddingRight: "10px", height: "30px"}} shadeA={shadeA} shadeB={shadeB} shadeC={shadeC} />
+      <div style={{display: "flex", flexDirection: "column", alignItems: "center", width: "132px"}}>
+        <ResponsiveButton selected={false} enabled={true} buttonAction={()=>{setShowUrl(!showUrl)}} label={showUrl ? "Hide" : "Show"} customStyle={{borderRadius: "5px", width: "3.5rem", height: "30px"}} shadeA={shadeA} shadeB={shadeB} shadeC={shadeC} />
+      </div>
+
+      {showUrl ? (<div style={{maxWidth: "100%"}}>{url.toLowerCase()}</div>) : null}
     </div>
   );
 }

--- a/src/components/QrComponent.jsx
+++ b/src/components/QrComponent.jsx
@@ -3,7 +3,7 @@ import QRCode from 'qrcode';
 
 import ResponsiveButton from './ResponsiveButton';
 
-const QrComponent = ({url, alignment}) => {
+const QrComponent = ({url, alignment, shadeA="#282828", shadeB="#303030", shadeC="#383838"}) => {
   const [src, setSrc] = useState("");
   const [qrHoverMsg, setQrHoverMsg] = useState("Click to copy URL to clipboard");
   const [showUrl, setShowUrl] = useState(false);
@@ -36,7 +36,7 @@ const QrComponent = ({url, alignment}) => {
       </div>
 
       {showUrl ? (<div style={{alignSelf: {alignment}}}>{url.toLowerCase()}</div>) : null}
-      <ResponsiveButton selected={false} enabled={true} buttonAction={()=>{setShowUrl(!showUrl)}} label={showUrl ? "Hide" : "Show"} customStyle={{borderRadius: "5px", width: "fit-content", paddingLeft: "10px", paddingRight: "10px", height: "30px"}} shadeA="#282828" shadeB="#303030" shadeC="#383838" />
+      <ResponsiveButton selected={false} enabled={true} buttonAction={()=>{setShowUrl(!showUrl)}} label={showUrl ? "Hide" : "Show"} customStyle={{borderRadius: "5px", width: "fit-content", paddingLeft: "10px", paddingRight: "10px", height: "30px"}} shadeA={shadeA} shadeB={shadeB} shadeC={shadeC} />
     </div>
   );
 }

--- a/src/components/ResponsiveButton.jsx
+++ b/src/components/ResponsiveButton.jsx
@@ -6,7 +6,7 @@ export default function ResponsiveButton({selected, enabled, buttonAction, onHov
   const [hovered, setHovered] = useState(false);
 
   return (
-  <div onMouseEnter={() => {setHovered(true); if (onHover) onHover();}} onMouseLeave={() => {setHovered(false); setClicked(false);}} onMouseDown={() => {setClicked(true)}} onMouseUp={() => {if (enabled) {buttonAction();} setClicked(false);}}>
+  <div className="ResponsiveButton" onMouseEnter={() => {setHovered(true); if (onHover) onHover();}} onMouseLeave={() => {setHovered(false); setClicked(false);}} onMouseDown={() => {setClicked(true)}} onMouseUp={() => {if (enabled) {buttonAction();} setClicked(false);}}>
     <ShadedButton selected={selected} hovered={hovered} pressed={clicked} enabled={enabled} icon={label} customStyle={customStyle} disabledStyle={disabledStyle} shadeA={shadeA} shadeB={shadeB} shadeC={shadeC} />
   </div>
   );

--- a/src/components/ServedItem.jsx
+++ b/src/components/ServedItem.jsx
@@ -11,7 +11,7 @@ export default function ServedItem({filename, url, size}) {
 
     <SimpleTextHeader primaryText={filename} secondaryText={`Size: ${sizeString}`} />
     <div className="right-panel">
-      <QrComponent url={url} />
+      <QrComponent url={url} alignment="end" />
     </div>
   </div>
 };

--- a/src/components/ServedItem.jsx
+++ b/src/components/ServedItem.jsx
@@ -11,7 +11,7 @@ export default function ServedItem({filename, url, size}) {
 
     <SimpleTextHeader primaryText={filename} secondaryText={`Size: ${sizeString}`} />
     <div className="right-panel">
-      <QrComponent url={url} alignment="end" />
+      <QrComponent url={url} alignment="end" shadeA="#303030" shadeB="#383838" shadeC="#404040" />
     </div>
   </div>
 };

--- a/src/components/pages.jsx
+++ b/src/components/pages.jsx
@@ -106,7 +106,7 @@ const Inbox = ({setSelectedRFile, inboxItems, setinboxItems, activeRFile, handle
             <div id="right-blank-panel" style={{width: "200px", flexGrow: 1}}>
                 <div style={{color: "white", fontSize: "0.9rem", margin: "0 auto", width: "100%", textAlign: "center"}}>Share this QR code to allow others to send you files:</div>
                 <div style={{width: "fit-content", margin: "0 auto", marginTop: "20px"}}>
-                <QrComponent url={inboxUrl} />
+                <QrComponent url={inboxUrl} alignment="center" />
                 </div>
             </div>
             ) : (

--- a/src/components/pages.jsx
+++ b/src/components/pages.jsx
@@ -81,6 +81,7 @@ const Inbox = ({setSelectedRFile, inboxItems, setinboxItems, activeRFile, handle
                 <h4 style={{marginBottom: "5px", marginTop: "5px", marginLeft: "12px" }}>Inbox</h4>
                 <div style={{display: "flex", flexDirection: "row", alignItems: "space-between", height: "25px"}}>
                     <span className="simple-text" style={{margin: "auto", marginLeft: "13px", fontSize: "0.8rem", height: "fit-content"}}>{inboxItems.length} file{inboxItems.length !== 1 ? "s" : ""}</span>
+                    {activeRFile !== null ? (<span style={{fontSize: "0.8rem", height: "fit-content", margin: "auto 13px auto auto"}} onClick={()=>{setSelectedRFile(null)}}>show QR</span>) : null}
                 </div>
                 </div>
 

--- a/src/components/pages.jsx
+++ b/src/components/pages.jsx
@@ -12,9 +12,9 @@ const Outbox = ({hostedFiles, setHostedFiles, openFile, handleAddText, addTextVa
 
     return (
         <div style={{display: "flex", flexDirection: "row", height: "100%", width: "100%"}}>
-            <div id="left-summary-panel">
+            <div id="left-summary-panel" style={{display: "flex", flexDirection: "column"}}>
                 <div>
-                    <div className="left-send-header" style={{ display: "flex", justifyItems: "space-between", flexDirection: "column", marginBottom: "0", paddingBottom: "4px" }}>
+                    <div className="left-send-header" onClick={() => {setSelectedSFile(null);}} style={{ display: "flex", justifyItems: "space-between", flexDirection: "column", marginBottom: "0", paddingBottom: "4px" }}>
                     <h4 style={{marginBottom: "5px", marginTop: "5px", marginLeft: "12px"}}>Outbox</h4>
                     <div style={{display: "flex", flexDirection: "row", alignItems: "space-between", height: "25px"}}>
                         <span className="simple-text" style={{margin: "auto", marginLeft: "13px", fontSize: "0.8rem", height: "fit-content"}}>{hostedFiles.length} file{hostedFiles.length !== 1 ? "s" : ""}</span>
@@ -53,6 +53,7 @@ const Outbox = ({hostedFiles, setHostedFiles, openFile, handleAddText, addTextVa
                     ))}
                     </div>
                 </div>
+                <div style={{flexGrow: "1"}} onClick={() => {setSelectedSFile(null);}} />
             </div>
             {activeSFile !== null ? (
             <div id="right-detail-panel" style={{
@@ -76,12 +77,11 @@ const Inbox = ({setSelectedRFile, inboxItems, setinboxItems, activeRFile, handle
     return (
         <div style={{display: "flex", flexDirection: "row", height: "100%", width: "100%"}}>
             <div id="left-summary-panel">
-            <div id="recv-panel">
+            <div id="recv-panel" style={{display: "flex", flexDirection: "column", height: "100%"}}>
                 <div className="left-recv-header" onClick={() => {setSelectedRFile(null);}} style={{ display: "flex", justifyItems: "space-between", flexDirection: "column", marginBottom: "0", paddingBottom: "4px" }}>
                 <h4 style={{marginBottom: "5px", marginTop: "5px", marginLeft: "12px" }}>Inbox</h4>
                 <div style={{display: "flex", flexDirection: "row", alignItems: "space-between", height: "25px"}}>
                     <span className="simple-text" style={{margin: "auto", marginLeft: "13px", fontSize: "0.8rem", height: "fit-content"}}>{inboxItems.length} file{inboxItems.length !== 1 ? "s" : ""}</span>
-                    {activeRFile !== null ? (<span style={{fontSize: "0.8rem", height: "fit-content", margin: "auto 13px auto auto"}} onClick={()=>{setSelectedRFile(null)}}>show QR</span>) : null}
                 </div>
                 </div>
 
@@ -101,6 +101,8 @@ const Inbox = ({setSelectedRFile, inboxItems, setinboxItems, activeRFile, handle
                     />
                 ))}
                 </div>
+
+                <div style={{flexGrow: "1"}} onClick={() => {setSelectedRFile(null);}} />
             </div>
             </div>
             {activeRFile === null ? (

--- a/src/components/pages.jsx
+++ b/src/components/pages.jsx
@@ -107,7 +107,7 @@ const Inbox = ({setSelectedRFile, inboxItems, setinboxItems, activeRFile, handle
             <div id="right-blank-panel" style={{width: "200px", flexGrow: 1}}>
                 <div style={{color: "white", fontSize: "0.9rem", margin: "0 auto", width: "100%", textAlign: "center"}}>Share this QR code to allow others to send you files:</div>
                 <div style={{width: "fit-content", margin: "0 auto", marginTop: "20px"}}>
-                <QrComponent url={inboxUrl} alignment="center" />
+                <QrComponent url={inboxUrl} alignment="center" shadeA="#282828" shadeB="#303030" shadeC="#383838" />
                 </div>
             </div>
             ) : (

--- a/src/index.css
+++ b/src/index.css
@@ -50,7 +50,7 @@ h4 {
   max-height: 148px;
 }
 
-.qr-wrapper {
+/* .qr-code {
   position: relative;
   text-align: center;
   font-size: 0.8rem;
@@ -60,7 +60,7 @@ h4 {
   border-radius: 8px;
 
   white-space: normal;
-}
+} */
 
 .qr-overlay {
   position: absolute;
@@ -72,7 +72,7 @@ h4 {
 
   background-color: #404040a0;
 }
-.qr-wrapper:hover .qr-overlay {
+.qr-code:hover .qr-overlay {
   opacity: 1;
 }
 

--- a/src/serverBehavior.js
+++ b/src/serverBehavior.js
@@ -21,7 +21,7 @@ async function urlWrapper(text) {
 module.exports = {
   serverBehavior: (projectRoot, addInboxItem, outboxItems) => { return async (req, res) => {
     const parsedUrl = url.parse(req.url, true);
-    const urlFilter = /^\/get\/(\d+)$/;
+    const urlFilter = /^\/get\/(\d+)$i/;
 
     console.log(`HTTP Server: Received request for ${parsedUrl.pathname}`);
 

--- a/src/serverBehavior.js
+++ b/src/serverBehavior.js
@@ -21,7 +21,7 @@ async function urlWrapper(text) {
 module.exports = {
   serverBehavior: (projectRoot, addInboxItem, outboxItems) => { return async (req, res) => {
     const parsedUrl = url.parse(req.url, true);
-    const urlFilter = /^\/get\/(\d+)$i/;
+    const urlFilter = /^\/get\/(\d+)$/i;
 
     console.log(`HTTP Server: Received request for ${parsedUrl.pathname}`);
 


### PR DESCRIPTION
Adds a button underneath every QR object that toggles the visibility of the raw URL.
Also makes the backend server regex case-insensitive

Also adds click handlers in the left sidebar that deselect a currently selected item, if one exists.