### PR TITLE
Smart default IP selector

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -141,12 +141,31 @@ async function addTextToOutbox(event, text) {
 }
 
 function getAnyIP() {
-  const addrs = listAddrs();
-  if (addrs.length > 0) {
-    return addrs[0];
-  } else {
+  const addrs = listAddrs(true);
+
+  if (addrs.length == 0) {
     return "0.0.0.0";
   }
+
+  if (addrs.length == 1) {
+    return addrs[0][0];
+  }
+
+  for (const addr of addrs) {
+    if (addr[1].includes("Wi-Fi") || (addr[1].includes("Ethernet") && addr[1].includes("vEthernet"))) {
+      return addr[0];
+    }
+  }
+
+  console.log("goons2");
+
+  for (const addr of addrs) {
+    if (addr[0].startsWith("192.168") || addr[0].startsWith("10.1")) {
+      return addr[0];
+    }
+  }
+
+  return addrs[0][0];
 }
 
 function getDefaultIP() {
@@ -168,16 +187,21 @@ function setIP(newIP) {
   userConfig.set('lastUsedIP', newIP);
 }
 
-function listAddrs() {
+function listAddrs(includeInterfaces = false) {
   const interfaces = os.networkInterfaces();
   let filteredAddrs = [];
   for (const name in interfaces) {
     const addrs = interfaces[name];
     for (const addr of addrs) {
       if (addr.family == 'IPv4' && !addr.internal && !addr.address.startsWith("169.254")) {
-        filteredAddrs.push(addr.address);
+        if (includeInterfaces == true) {
+          filteredAddrs.push([addr.address, name]);
+        } else {
+          filteredAddrs.push(addr.address);
+        }
       }
     }
+    // console.log("interface: ", name, ": ", addrs);
   }
   return filteredAddrs;
 }


### PR DESCRIPTION
This PR adds more complex functionality in case the last used IP is not available anymore. Now, the default selection process takes the list of "usable" IPs from all interfaces, and does the following, in order:

Searches the list for an IP that is associated with an interface containing the string "Wi-Fi", or the string "Ethernet", unless it is preceded by "v" (vEthernet), in which case it is not considered. If an IP is found that satisfies this criteria, it is immediately returned.

If none are found to satisfy the above condition, the list is searched for an IP starting with either "192.168" or "10.1". If one is found, it is immediately returned.

If no IP has been returned yet, return the first one in the list.